### PR TITLE
Add grade routes blueprint

### DIFF
--- a/src/grade_routes.py
+++ b/src/grade_routes.py
@@ -1,0 +1,37 @@
+from flask import Blueprint, render_template
+
+# Blueprint handling grade-level pages.
+grade_bp = Blueprint('grade', __name__)
+
+
+@grade_bp.route('/Primary_Grade_3_Mathematics')
+def primary_grade_3():
+    return render_template('Primary_Grade_3.html')
+
+
+@grade_bp.route('/Primary_Grade_4_Mathematics')
+def primary_grade_4():
+    return render_template('Primary_Grade_4.html')
+
+
+@grade_bp.route('/Primary_Grade_5_Mathematics')
+def primary_grade_5():
+    return render_template('Primary_Grade_5.html')
+
+
+@grade_bp.route('/Primary_Grade_6_Mathematics')
+@grade_bp.route('/PSLE')
+def primary_grade_6():
+    return render_template('Primary_Grade_6.html')
+
+
+@grade_bp.route('/Secondary-1-Grade-7-Mathematics')
+@grade_bp.route('/Secondary-1')
+def secondary_1():
+    return render_template('Grade-7/Grade-7.html')
+
+
+@grade_bp.route('/Unfinished-Worksheets')
+def unfinished_worksheets():
+    # Placeholder implementation without database lookups.
+    return render_template('Unfinished-Worksheets.html')

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@ from auth_routes import auth_bp, login_manager
 from redirect_routes import redirect_bp
 from contact_routes import contact_bp
 from static_routes import static_bp
+from grade_routes import grade_bp
 
 def create_app():
     app = Flask(__name__, template_folder='templates')
@@ -17,6 +18,7 @@ def create_app():
     app.register_blueprint(redirect_bp)
     app.register_blueprint(contact_bp)
     app.register_blueprint(static_bp)
+    app.register_blueprint(grade_bp)
 
     return app
 


### PR DESCRIPTION
## Summary
- add `grade_routes.py` with blueprint handling grade pages
- register `grade_bp` in `create_app`

## Testing
- `python3 -m py_compile src/grade_routes.py src/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6841373977388333915d73ed1835f183